### PR TITLE
add Windows support

### DIFF
--- a/orderbook/orderbook.c
+++ b/orderbook/orderbook.c
@@ -110,31 +110,31 @@ int Orderbook_init(Orderbook *self, PyObject *args, PyObject *kwds)
 PyObject* Orderbook_todict(const Orderbook *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *ret = PyDict_New();
-    if (__builtin_expect(!ret, 0)) {
+    if (EXPECT(!ret, 0)) {
         return NULL;
     }
 
     PyObject *bids = SortedDict_todict(self->bids, NULL);
-    if (__builtin_expect(!bids, 0)) {
+    if (EXPECT(!bids, 0)) {
         Py_DECREF(ret);
         return NULL;
     }
 
     PyObject *asks = SortedDict_todict(self->asks, NULL);
-    if (__builtin_expect(!asks, 0)) {
+    if (EXPECT(!asks, 0)) {
         Py_DECREF(bids);
         Py_DECREF(ret);
         return NULL;
     }
 
-    if (__builtin_expect(PyDict_SetItemString(ret, "bid", bids) < 0, 0)) {
+    if (EXPECT(PyDict_SetItemString(ret, "bid", bids) < 0, 0)) {
         Py_DECREF(asks);
         Py_DECREF(bids);
         Py_DECREF(ret);
         return NULL;
     }
 
-    if (__builtin_expect(PyDict_SetItemString(ret, "ask", asks) < 0, 0)) {
+    if (EXPECT(PyDict_SetItemString(ret, "ask", asks) < 0, 0)) {
         Py_DECREF(asks);
         Py_DECREF(bids);
         Py_DECREF(ret);
@@ -149,16 +149,16 @@ PyObject* Orderbook_todict(const Orderbook *self, PyObject *Py_UNUSED(ignored))
 
 PyObject* Orderbook_checksum(const Orderbook *self, PyObject *Py_UNUSED(ignored))
 {
-    if (__builtin_expect(self->checksum == INVALID_CHECKSUM_FORMAT, 0)) {
+    if (EXPECT(self->checksum == INVALID_CHECKSUM_FORMAT, 0)) {
         PyErr_SetString(PyExc_ValueError, "no checksum format specified");
         return NULL;
     }
 
-    if (__builtin_expect(update_keys(self->bids), 0)) {
+    if (EXPECT(update_keys(self->bids), 0)) {
         return NULL;
     }
 
-    if (__builtin_expect(update_keys(self->asks), 0)) {
+    if (EXPECT(update_keys(self->asks), 0)) {
         return NULL;
     }
 
@@ -177,13 +177,13 @@ Py_ssize_t Orderbook_len(const Orderbook *self)
 
 PyObject *Orderbook_getitem(const Orderbook *self, PyObject *key)
 {
-    if (__builtin_expect(!PyUnicode_Check(key), 0)) {
+    if (EXPECT(!PyUnicode_Check(key), 0)) {
         PyErr_SetString(PyExc_ValueError, "key must one of bid/ask");
         return NULL;
     }
 
     PyObject *str = PyUnicode_AsEncodedString(key, "UTF-8", "strict");
-    if (__builtin_expect(!str, 0)) {
+    if (EXPECT(!str, 0)) {
         return NULL;
     }
 
@@ -206,36 +206,36 @@ PyObject *Orderbook_getitem(const Orderbook *self, PyObject *key)
 
 int Orderbook_setitem(const Orderbook *self, PyObject *key, PyObject *value)
 {
-    if (__builtin_expect(!PyUnicode_Check(key), 0)) {
+    if (EXPECT(!PyUnicode_Check(key), 0)) {
         PyErr_SetString(PyExc_ValueError, "key must one of bid/ask");
         return -1;
     }
 
     PyObject *str = PyUnicode_AsEncodedString(key, "UTF-8", "strict");
-    if (__builtin_expect(!str, 0)) {
+    if (EXPECT(!str, 0)) {
         return -1;
     }
 
     enum side_e key_int = check_key(PyBytes_AsString(str));
     Py_DECREF(str);
 
-    if (__builtin_expect(key_int == INVALID_SIDE, 0)) {
+    if (EXPECT(key_int == INVALID_SIDE, 0)) {
         PyErr_SetString(PyExc_ValueError, "key must one of bid/ask");
         return -1;
     }
 
-    if (__builtin_expect(!value, 0)) {
+    if (EXPECT(!value, 0)) {
         PyErr_SetString(PyExc_ValueError, "cannot delete");
         return -1;
     }
 
-    if (__builtin_expect(!PyDict_Check(value), 0)) {
+    if (EXPECT(!PyDict_Check(value), 0)) {
         PyErr_SetString(PyExc_ValueError, "value must be a dict");
         return -1;
     }
 
     PyObject *copy = PyDict_Copy(value);
-    if (__builtin_expect(!copy, 0)) {
+    if (EXPECT(!copy, 0)) {
         return -1;
     }
 
@@ -291,18 +291,18 @@ PyMODINIT_FUNC PyInit_order_book(void)
 static int kraken_string_builder(PyObject *pydata, uint8_t *data, int *pos)
 {
     PyObject *repr = PyObject_Str(pydata);
-    if (__builtin_expect(!repr, 0)) {
+    if (EXPECT(!repr, 0)) {
         return -1;
     }
 
     PyObject* str = PyUnicode_AsEncodedString(repr, "UTF-8", "strict");
     Py_DECREF(repr);
-    if (__builtin_expect(!str, 0)) {
+    if (EXPECT(!str, 0)) {
         return -1;
     }
 
     const char *string = PyBytes_AS_STRING(str);
-    if (__builtin_expect(!string, 0)) {
+    if (EXPECT(!string, 0)) {
         Py_DECREF(str);
         return -1;
     }
@@ -334,11 +334,11 @@ static int kraken_populate_side(const SortedDict *side, uint8_t *data, int *pos)
         PyObject *price = PyTuple_GET_ITEM(side->keys, i);
         PyObject *size = PyDict_GetItem(side->data, price);
 
-        if (__builtin_expect(kraken_string_builder(price, data, pos), 0)) {
+        if (EXPECT(kraken_string_builder(price, data, pos), 0)) {
             return -1;
         }
 
-        if (__builtin_expect(kraken_string_builder(size, data, pos), 0)) {
+        if (EXPECT(kraken_string_builder(size, data, pos), 0)) {
             return -1;
         }
     }
@@ -349,7 +349,7 @@ static int kraken_populate_side(const SortedDict *side, uint8_t *data, int *pos)
 
 static PyObject* kraken_checksum(const Orderbook *ob)
 {
-    if (__builtin_expect(ob->max_depth && ob->max_depth < 10, 0)) {
+    if (EXPECT(ob->max_depth && ob->max_depth < 10, 0)) {
         PyErr_SetString(PyExc_ValueError, "Max depth is less than minimum number of levels for Kraken checksum");
         return NULL;
     }
@@ -357,17 +357,17 @@ static PyObject* kraken_checksum(const Orderbook *ob)
     uint32_t bids_size = SortedDict_len(ob->bids);
     uint32_t asks_size = SortedDict_len(ob->asks);
 
-    if (__builtin_expect(bids_size < 10 || asks_size < 10, 0)) {
+    if (EXPECT(bids_size < 10 || asks_size < 10, 0)) {
         PyErr_SetString(PyExc_ValueError, "Depth is less than minimum number of levels for Kraken checksum");
         return NULL;
     }
 
     int pos = 0;
-    if (__builtin_expect(kraken_populate_side(ob->asks, ob->checksum_buffer, &pos), 0)) {
+    if (EXPECT(kraken_populate_side(ob->asks, ob->checksum_buffer, &pos), 0)) {
         return NULL;
     }
 
-    if (__builtin_expect(kraken_populate_side(ob->bids, ob->checksum_buffer, &pos), 0)) {
+    if (EXPECT(kraken_populate_side(ob->bids, ob->checksum_buffer, &pos), 0)) {
         return NULL;
     }
 
@@ -379,18 +379,18 @@ static PyObject* kraken_checksum(const Orderbook *ob)
 static int ftx_string_builder(PyObject *pydata, uint8_t *data, int *pos)
 {
     PyObject *repr = PyObject_Str(pydata);
-    if (__builtin_expect(!repr, 0)) {
+    if (EXPECT(!repr, 0)) {
         return -1;
     }
 
     PyObject* str = PyUnicode_AsEncodedString(repr, "UTF-8", "strict");
     Py_DECREF(repr);
-    if (__builtin_expect(!str, 0)) {
+    if (EXPECT(!str, 0)) {
         return -1;
     }
 
     const char *string = PyBytes_AS_STRING(str);
-    if (__builtin_expect(!string, 0)) {
+    if (EXPECT(!string, 0)) {
         Py_DECREF(str);
         return -1;
     }
@@ -407,7 +407,7 @@ static int ftx_string_builder(PyObject *pydata, uint8_t *data, int *pos)
 
 static PyObject* ftx_checksum(const Orderbook *ob, const uint32_t depth)
 {
-    if (__builtin_expect(ob->max_depth && ob->max_depth < depth, 0)) {
+    if (EXPECT(ob->max_depth && ob->max_depth < depth, 0)) {
         PyErr_SetString(PyExc_ValueError, "Max depth is less than minimum number of levels for checksum");
         return NULL;
     }
@@ -423,11 +423,11 @@ static PyObject* ftx_checksum(const Orderbook *ob, const uint32_t depth)
             price = PyTuple_GET_ITEM(ob->bids->keys, i);
             size = PyDict_GetItem(ob->bids->data, price);
 
-            if (__builtin_expect(ftx_string_builder(price, ob->checksum_buffer, &pos), 0)) {
+            if (EXPECT(ftx_string_builder(price, ob->checksum_buffer, &pos), 0)) {
                 return NULL;
             }
 
-            if (__builtin_expect(ftx_string_builder(size, ob->checksum_buffer, &pos), 0)) {
+            if (EXPECT(ftx_string_builder(size, ob->checksum_buffer, &pos), 0)) {
                 return NULL;
             }
         }
@@ -436,11 +436,11 @@ static PyObject* ftx_checksum(const Orderbook *ob, const uint32_t depth)
             price = PyTuple_GET_ITEM(ob->asks->keys, i);
             size = PyDict_GetItem(ob->asks->data, price);
 
-            if (__builtin_expect(ftx_string_builder(price, ob->checksum_buffer, &pos), 0)) {
+            if (EXPECT(ftx_string_builder(price, ob->checksum_buffer, &pos), 0)) {
                 return NULL;
             }
 
-            if (__builtin_expect(ftx_string_builder(size, ob->checksum_buffer, &pos), 0)) {
+            if (EXPECT(ftx_string_builder(size, ob->checksum_buffer, &pos), 0)) {
                 return NULL;
             }
         }

--- a/orderbook/sorteddict.c
+++ b/orderbook/sorteddict.c
@@ -160,17 +160,17 @@ inline int update_keys(SortedDict *self) {
 
     PyObject *keys = PyDict_Keys(self->data);
 
-    if (__builtin_expect(!keys, 0)) {
+    if (EXPECT(!keys, 0)) {
         return 1;
     }
 
-    if (__builtin_expect(PyList_Sort(keys) < 0, 0)) {
+    if (EXPECT(PyList_Sort(keys) < 0, 0)) {
         Py_DECREF(keys);
         return 1;
     }
 
     if (self->ordering == DESCENDING) {
-        if (__builtin_expect(PyList_Reverse(keys) < 0, 0)) {
+        if (EXPECT(PyList_Reverse(keys) < 0, 0)) {
             Py_DECREF(keys);
             return 1;
         }
@@ -178,7 +178,7 @@ inline int update_keys(SortedDict *self) {
 
     PyObject *ret = PySequence_Tuple(keys);
     Py_DECREF(keys);
-    if (__builtin_expect(!ret, 0)) {
+    if (EXPECT(!ret, 0)) {
         return 1;
     }
 
@@ -195,7 +195,7 @@ inline int update_keys(SortedDict *self) {
 
 PyObject* SortedDict_keys(SortedDict *self, PyObject *Py_UNUSED(ignored))
 {
-    if (__builtin_expect(update_keys(self), 0)) {
+    if (EXPECT(update_keys(self), 0)) {
         return NULL;
     }
 
@@ -214,29 +214,29 @@ PyObject* SortedDict_keys(SortedDict *self, PyObject *Py_UNUSED(ignored))
 PyObject* SortedDict_index(SortedDict *self, PyObject *index)
 {
     long i = PyLong_AsLong(index);
-    if (__builtin_expect(PyErr_Occurred() != NULL, 0)) {
+    if (EXPECT(PyErr_Occurred() != NULL, 0)) {
         return NULL;
     }
 
-    if (__builtin_expect(update_keys(self), 0)) {
+    if (EXPECT(update_keys(self), 0)) {
         return NULL;
     }
 
     // new reference
     PyObject *key = PySequence_GetItem(self->keys, i);
-    if (__builtin_expect(!key, 0)) {
+    if (EXPECT(!key, 0)) {
         return NULL;
     }
 
     // borrowed reference
     PyObject *value = PyDict_GetItem(self->data, key);
-    if (__builtin_expect(!value, 0)) {
+    if (EXPECT(!value, 0)) {
         Py_DECREF(key);
         return value;
     }
 
     PyObject *ret = PyTuple_New(2);
-    if (__builtin_expect(!ret, 0)) {
+    if (EXPECT(!ret, 0)) {
         Py_DECREF(key);
         return NULL;
     }
@@ -252,11 +252,11 @@ PyObject* SortedDict_index(SortedDict *self, PyObject *index)
 PyObject* SortedDict_todict(SortedDict *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *ret = PyDict_New();
-    if (__builtin_expect(!ret, 0)) {
+    if (EXPECT(!ret, 0)) {
         return NULL;
     }
 
-    if (__builtin_expect(update_keys(self), 0)) {
+    if (EXPECT(update_keys(self), 0)) {
         return NULL;
     }
 
@@ -278,23 +278,23 @@ PyObject* SortedDict_todict(SortedDict *self, PyObject *Py_UNUSED(ignored))
 PyObject* SortedDict_truncate(SortedDict *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->depth) {
-        if (__builtin_expect(update_keys(self), 0)) {
+        if (EXPECT(update_keys(self), 0)) {
             return NULL;
         }
 
         PyObject *delete = PySequence_GetSlice(self->keys, self->depth, PyDict_Size(self->data));
-        if (__builtin_expect(!delete, 0)) {
+        if (EXPECT(!delete, 0)) {
             return NULL;
         }
 
         int len = PySequence_Length(delete);
-        if (__builtin_expect(len == -1, 0)) {
+        if (EXPECT(len == -1, 0)) {
             Py_DECREF(delete);
             return NULL;
         }
 
         for (int i = 0; i < len; ++i) {
-            if (__builtin_expect(PyDict_DelItem(self->data, PySequence_Fast_GET_ITEM(delete, i)) == -1, 0)) {
+            if (EXPECT(PyDict_DelItem(self->data, PySequence_Fast_GET_ITEM(delete, i)) == -1, 0)) {
                 Py_DECREF(delete);
                 return NULL;
             }
@@ -305,7 +305,7 @@ PyObject* SortedDict_truncate(SortedDict *self, PyObject *Py_UNUSED(ignored))
             self->dirty = true;
         }
 
-        if (__builtin_expect(update_keys(self), 0)) {
+        if (EXPECT(update_keys(self), 0)) {
             return NULL;
         }
     }
@@ -333,7 +333,7 @@ PyObject *SortedDict_getitem(SortedDict *self, PyObject *key)
         return ret;
     }
 
-    if (__builtin_expect(!PyErr_Occurred(), 0)) {
+    if (EXPECT(!PyErr_Occurred(), 0)) {
         PyErr_SetString(PyExc_KeyError, "key does not exist");
     }
 
@@ -347,9 +347,9 @@ int SortedDict_setitem(SortedDict *self, PyObject *key, PyObject *value)
     if (value) {
         int ret = PyDict_SetItem(self->data, key, value);
 
-        if (__builtin_expect(ret == -1, 0)) {
+        if (EXPECT(ret == -1, 0)) {
             return ret;
-        } else if (__builtin_expect(self->truncate && !SortedDict_truncate(self, NULL), 0)) {
+        } else if (EXPECT(self->truncate && !SortedDict_truncate(self, NULL), 0)) {
             return -1;
         }
 
@@ -372,12 +372,12 @@ PyObject *SortedDict_next(SortedDict *self)
     if (self->iterator_index == -1) {
         self->iterator_index = 0;
 
-        if (__builtin_expect(update_keys(self), 0)) {
+        if (EXPECT(update_keys(self), 0)) {
             return NULL;
         }
 
         Py_ssize_t size = PySequence_Fast_GET_SIZE(self->keys);
-        if (__builtin_expect(size == 0, 0)){
+        if (EXPECT(size == 0, 0)){
             return NULL;
         }
 

--- a/orderbook/utils.h
+++ b/orderbook/utils.h
@@ -7,6 +7,12 @@ associated with this software.
 #ifndef __UTILS__
 #define __UTILS__
 
+#if defined(_WIN32)
+#define EXPECT(EXPR, VAL) (EXPR)
+#else
+#define EXPECT(EXPR, VAL) __builtin_expect((EXPR), (VAL))
+#endif
+
 enum side_e {
     BID,
     ASK,

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ Please see the LICENSE file for the terms and conditions
 associated with this software.
 '''
 import glob
+import os
 from os import path
 from setuptools import setup, Extension, find_packages
 from setuptools.command.test import test as TestCommand
@@ -12,7 +13,8 @@ import sys
 
 
 sources = glob.glob('orderbook/*.c')
-orderbook = Extension('order_book', sources=sources, extra_compile_args=["-O3"])
+optimize_arg = "/O2" if os.name == "nt" else "-O3"
+orderbook = Extension('order_book', sources=sources, extra_compile_args=[optimize_arg])
 
 
 def get_long_description():


### PR DESCRIPTION
This PR adds Windows support. Currently the build fails because on Windows extensions are automatically compiled with MSVC, which uses "/O2" and does not have the macro __builtin_expect.

All tests are passing on Windows.

Summary of changes:
setup.py: Use /O2 instead of -O3 if on Windows, otherwise continue to use -O3.
*.c files: Define and use EXPECTED(EXPR, VAL) macro in utils.h that expands to identity on Windows, or __builtin_expect otherwise.