### PR TITLE
Fix superfluous reference incrementing of asks/bids.

### DIFF
--- a/orderbook/orderbook.c
+++ b/orderbook/orderbook.c
@@ -25,22 +25,20 @@ PyObject *Orderbook_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self = (Orderbook *) type->tp_alloc(type, 0);
     if (self != NULL) {
         self->bids = (SortedDict *)SortedDict_new(&SortedDictType, NULL, NULL);
-        self->bids->ordering = DESCENDING;
-        if (!self->bids) {
+        if (self->bids == NULL) {
             Py_DECREF(self);
             return NULL;
         }
-        Py_INCREF(self->bids);
+        self->bids->ordering = DESCENDING;
 
         self->asks = (SortedDict *)SortedDict_new(&SortedDictType, NULL, NULL);
-        self->asks->ordering = ASCENDING;
-        if (!self->asks) {
+        if (self->asks == NULL) {
             Py_DECREF(self->bids);
             Py_DECREF(self);
             return NULL;
         }
+        self->asks->ordering = ASCENDING;
 
-        Py_INCREF(self->asks);
         self->max_depth = 0;
         self->truncate = false;
         self->checksum = INVALID_CHECKSUM_FORMAT;


### PR DESCRIPTION
The allocation of an `Orderbook` leaks references to its `bids` and `asks` members due to a superfluous `Py_INCREF` for each of them. The deallocation of an `OrderBook` instance will therefore leak memory, as their reference count will not reach 0. In addition, when memory has run out, we get a `segfault` while accessing a member on an unallocated `SortedDict` struct.

A minimal example to reproduce the problem is:
```python
from order_book import OrderBook

while True:
    ob = OrderBook()
    del ob
```
I recommend limiting the memory with `ulimit -sV 64000`.

Note that this example does not result in a `MemoryError`, but in a `segfault` due to the second bug.

To resolve both issues, we remove the unnecessary `Py_INCREF` and move the initialization of the `ordering` member _after_ the NULL check.