### PR TITLE
Avoid segmentation fault when calculating the checksum of an empty orderbook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.5.0
+ * Bugfix: fix segmentation fault when calculating checksum on empty orderbook
+ * Bugfix: fix missing reference decrement
+
 ### 0.4.3 (2022-05-29)
  * Bugfix: handle scientific notation of small values in Kraken checksum
  * Update: calculate Kraken checksum on order books less than 10 levels deep

--- a/orderbook/orderbook.c
+++ b/orderbook/orderbook.c
@@ -485,6 +485,13 @@ static int floatstr_string_builder(PyObject *pydata, uint8_t *data, int *pos)
     }
 
     PyObject *flt = PyFloat_FromString(repr);
+    if (EXPECT(!flt, 0)) {
+        Py_DECREF(repr);
+        return -1;
+    }
+
+    Py_DECREF(repr);
+
     if (EXPECT(str_string_builder(flt, data, pos), 0)) {
         Py_DECREF(flt);
         return -1;
@@ -608,7 +615,9 @@ static PyObject* alternating_checksum(const Orderbook *ob, const uint32_t depth,
         }
     }
 
-    unsigned long ret = crc32_table(ob->checksum_buffer, pos-1);
+    int len = (pos > 0) ? pos - 1 : 0;
+
+    unsigned long ret = crc32_table(ob->checksum_buffer, len);
 
     return PyLong_FromUnsignedLong(ret);
 }

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -158,6 +158,9 @@ def test_kraken_checksum():
 
     assert ob.checksum() == 1611253991
 
+    ob = OrderBook(checksum_format='KRAKEN')
+    assert ob.checksum() == 0
+
 
 def test_okx_checksum():
     ob = OrderBook(checksum_format='OKX')
@@ -246,6 +249,9 @@ def test_okx_checksum():
 
     assert ob.checksum() == 2399502091
 
+    ob = OrderBook(checksum_format='OKX')
+    assert ob.checksum() == 0
+
 
 def test_bitget_checksum():
     ob = OrderBook(checksum_format='BITGET')
@@ -323,6 +329,9 @@ def test_bitget_checksum():
         ob.bids[Decimal(b[0])] = Decimal(b[1])
 
     assert ob.checksum() == 3720106698
+
+    ob = OrderBook(checksum_format='BITGET')
+    assert ob.checksum() == 0
 
 
 def test_okcoin_checksum():
@@ -540,4 +549,7 @@ def test_ftx_checksum():
         ob.bids[Decimal(b[0])] = Decimal(b[1])
 
     assert ob.checksum() == 3169411573
+
+    ob = OrderBook(checksum_format='FTX')
+    assert ob.checksum() == 0
 


### PR DESCRIPTION
When an orderbook is empty, then checksum calculation (except for Kraken) would result in a call to `crc32_table` with `len` set as `-1`. This leads to the segmentation fault that was mentioned in the comments of https://github.com/bmoscon/orderbook/pull/16.

This commit also adds a check on the return value of `PyFloat_FromString` in `floatstr_string_builder`, as well as fixing a missing reference decrement in the same function.