### PR TITLE
Add to_list Implementation

### DIFF
--- a/orderbook/sorteddict.c
+++ b/orderbook/sorteddict.c
@@ -339,11 +339,17 @@ PyObject* SortedDict_todict(SortedDict *self, PyObject *unused, PyObject *kwargs
 }
 
 
-PyObject* SortedDict_tolist(SortedDict *self, PyObject *n_levels_inp)
+PyObject* SortedDict_tolist(SortedDict *self, PyObject *args, PyObject *kwargs)
 {
-    long n_levels = PyLong_AsLong(n_levels_inp);
-    long data_len = (long) PyDict_Size(self->data);
-    // Set n_levels to self->depth if n_levels is negative (default)
+    static char* keywords[] = {"n_levels", NULL};
+    
+    int n_levels = -1;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|i", keywords, &n_levels)) {
+        return NULL;
+    }
+
+    int data_len = PyDict_Size(self->data);
+    // Set n_levels to data_len if n_levels is the default value
     if (n_levels == -1 | n_levels > data_len) {
         n_levels = data_len;
     }

--- a/orderbook/sorteddict.h
+++ b/orderbook/sorteddict.h
@@ -42,7 +42,7 @@ int SortedDict_init(SortedDict *self, PyObject *args, PyObject *kwds);
 PyObject* SortedDict_keys(SortedDict *self, PyObject *Py_UNUSED(ignored));
 PyObject* SortedDict_index(SortedDict *self, PyObject *index);
 PyObject* SortedDict_todict(SortedDict *self, PyObject *unused, PyObject *kwargs);
-PyObject* SortedDict_tolist(SortedDict *self, PyObject *n_levels_inp);
+PyObject* SortedDict_tolist(SortedDict *self, PyObject *args, PyObject *kwargs);
 PyObject* SortedDict_truncate(SortedDict *self, PyObject *Py_UNUSED(ignored));
 
 Py_ssize_t SortedDict_len(const SortedDict *self);
@@ -69,7 +69,7 @@ static PyMethodDef SortedDict_methods[] = {
     {"index", (PyCFunction) SortedDict_index, METH_O, "return a key, value tuple at index N"},
     {"truncate", (PyCFunction) SortedDict_truncate, METH_NOARGS, "truncate to length max_depth"},
     {"to_dict", (PyCFunction) SortedDict_todict, METH_VARARGS | METH_KEYWORDS, "return a python dictionary, sorted by keys"},
-    {"to_list", (PyCFunction) SortedDict_tolist, METH_O, "return a list of key, value tuple with length specified in input argument. if depth passed is -1 or larger than length of self->data, return items with length of self->data."},
+    {"to_list", (PyCFunction) SortedDict_tolist, METH_VARARGS | METH_KEYWORDS, "return a list of key, value tuple with length specified in input argument. if no argument is passed or the argument is larger than length of self->data, return items with length of self->data."},
     {NULL}
 };
 

--- a/orderbook/sorteddict.h
+++ b/orderbook/sorteddict.h
@@ -42,6 +42,7 @@ int SortedDict_init(SortedDict *self, PyObject *args, PyObject *kwds);
 PyObject* SortedDict_keys(SortedDict *self, PyObject *Py_UNUSED(ignored));
 PyObject* SortedDict_index(SortedDict *self, PyObject *index);
 PyObject* SortedDict_todict(SortedDict *self, PyObject *unused, PyObject *kwargs);
+PyObject* SortedDict_tolist(SortedDict *self, PyObject *n_levels_inp);
 PyObject* SortedDict_truncate(SortedDict *self, PyObject *Py_UNUSED(ignored));
 
 Py_ssize_t SortedDict_len(const SortedDict *self);
@@ -68,6 +69,7 @@ static PyMethodDef SortedDict_methods[] = {
     {"index", (PyCFunction) SortedDict_index, METH_O, "return a key, value tuple at index N"},
     {"truncate", (PyCFunction) SortedDict_truncate, METH_NOARGS, "truncate to length max_depth"},
     {"to_dict", (PyCFunction) SortedDict_todict, METH_VARARGS | METH_KEYWORDS, "return a python dictionary, sorted by keys"},
+    {"to_list", (PyCFunction) SortedDict_tolist, METH_O, "return a list of key, value tuple with length specified in input argument. if depth passed is -1 or larger than length of self->data, return items with length of self->data."},
     {NULL}
 };
 

--- a/perf/performance_test.py
+++ b/perf/performance_test.py
@@ -25,7 +25,7 @@ def profile(f):
         startt = time.time()
         ret = f(*args, **kwargs)
         total_time = time.time() - startt
-        print("Time:", total_time)
+        print(f"Time: {total_time * 1000:.6f} ms")
         return ret
     return wrapper
 
@@ -85,6 +85,8 @@ def random_data_test(size):
             values.append(random.uniform(-100000.0, 100000.0))
         values = set(values)
 
+    print("===== Write Performance =====")
+
     @profile
     def test_ordered(dictionary):
         for v in values:
@@ -119,6 +121,34 @@ def random_data_test(size):
     test_ordered(python_sd)
     print(f"Python dict (non sorted) with {size} entries")
     test_unordered(raw_python)
+
+    print("===== Read Performance =====")
+    @profile
+    def access_top10_c_index(c_dictionary):
+        for idx in range(10):
+            a = c_dictionary.index(idx)
+
+    @profile
+    def access_top10_iter(dictionary):
+        for idx, key in enumerate(dictionary):
+            a = dictionary[key]
+            if idx >= 10:
+                break
+
+    print(f"C lib with {size} entries (access)")
+    
+    print(f"- index impl ", end="")
+    access_top10_c_index(asc)
+    
+    print(f"- iter impl (incorrect when called multiple times) ", end="")
+    access_top10_iter(asc)
+    
+    print(f"Orderbook SortedDict Python lib with {size} entries (access)")
+    access_top10_iter(python_sd)
+    
+    print(f"Python dict (non sorted) with {size} entries (access)")
+    access_top10_iter(raw_python)
+
 
 
 def random_data_performance():

--- a/perf/performance_test.py
+++ b/perf/performance_test.py
@@ -129,6 +129,13 @@ def random_data_test(size):
             a = c_dictionary.index(idx)
 
     @profile
+    def access_top10_c_keys(c_dictionary):
+        for idx, key in enumerate(c_dictionary.keys()):
+            if idx >= 10:
+                break
+            a = c_dictionary[key]
+
+    @profile
     def access_top10_c_tolist(c_dictionary):
         a = c_dictionary.to_list(10)
 
@@ -154,6 +161,9 @@ def random_data_test(size):
     
     print(f"- todict impl ", end="")
     access_top10_c_todict(asc)
+
+    print(f"- keys impl ", end="")
+    access_top10_c_keys(asc)
 
     print(f"- iter impl (incorrect when called multiple times) ", end="")
     access_top10_iter(asc)

--- a/perf/performance_test.py
+++ b/perf/performance_test.py
@@ -129,6 +129,18 @@ def random_data_test(size):
             a = c_dictionary.index(idx)
 
     @profile
+    def access_top10_c_tolist(c_dictionary):
+        a = c_dictionary.to_list(10)
+
+    @profile
+    def access_top10_c_todict(c_dictionary):
+        d = c_dictionary.to_dict()
+        for idx, key in enumerate(d):
+            a = d[key]
+            if idx >= 10:
+                break
+
+    @profile
     def access_top10_iter(dictionary):
         for idx, key in enumerate(dictionary):
             a = dictionary[key]
@@ -140,8 +152,14 @@ def random_data_test(size):
     print(f"- index impl ", end="")
     access_top10_c_index(asc)
     
+    print(f"- todict impl ", end="")
+    access_top10_c_todict(asc)
+
     print(f"- iter impl (incorrect when called multiple times) ", end="")
     access_top10_iter(asc)
+
+    print(f"- tolist impl ", end="")
+    access_top10_c_tolist(asc)
     
     print(f"Orderbook SortedDict Python lib with {size} entries (access)")
     access_top10_iter(python_sd)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class Test(TestCommand):
 
 setup(
     name='order_book',
-    version='0.5.1',
+    version='0.5.0',
     author="Bryant Moscon",
     author_email="bmoscon@gmail.com",
     description="A fast orderbook implementation, in C, for Python",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class Test(TestCommand):
 
 setup(
     name='order_book',
-    version='0.5.0',
+    version='0.5.1',
     author="Bryant Moscon",
     author_email="bmoscon@gmail.com",
     description="A fast orderbook implementation, in C, for Python",

--- a/tests/test_sorteddict.py
+++ b/tests/test_sorteddict.py
@@ -154,7 +154,7 @@ def test_to_list():
         asc[v] = str(v)
         desc[v] = str(v)
 
-    lst = asc.to_list(-1)
+    lst = asc.to_list()
     _keys = list(list(zip(*lst))[0])
     assert _keys == list(asc.keys())
     assert sorted(_keys) == _keys
@@ -166,7 +166,7 @@ def test_to_list():
             assert val > previous
         previous = val
 
-    lst = desc.to_list(-1)
+    lst = desc.to_list()
     _keys = list(list(zip(*lst))[0])
     assert _keys == list(desc.keys())
     assert list(reversed(sorted(_keys))) == _keys

--- a/tests/test_sorteddict.py
+++ b/tests/test_sorteddict.py
@@ -140,6 +140,81 @@ def test_to_dict():
             d[key] < previous
         previous = d[key]
 
+def test_to_list():
+    random.seed()
+    values = []
+    asc = SortedDict(ordering='ASC')
+    desc = SortedDict(ordering='DESC')
+
+    for _ in range(2000):
+        values.append(random.uniform(0.0, 100000.0))
+    values = set(values)
+
+    for v in values:
+        asc[v] = str(v)
+        desc[v] = str(v)
+
+    lst = asc.to_list(-1)
+    _keys = list(list(zip(*lst))[0])
+    assert _keys == list(asc.keys())
+    assert sorted(_keys) == _keys
+    previous = None
+    for key, val in lst:
+        assert val == asc[key]
+        val = float(val)
+        if previous:
+            assert val > previous
+        previous = val
+
+    lst = desc.to_list(-1)
+    _keys = list(list(zip(*lst))[0])
+    assert _keys == list(desc.keys())
+    assert list(reversed(sorted(_keys))) == _keys
+    previous = None
+    for key, val in lst:
+        assert val == desc[key]
+        val = float(val)
+        if previous:
+            assert val < previous
+        previous = val
+
+def test_to_list_specified_length():
+    random.seed()
+    values = []
+    asc = SortedDict(ordering='ASC')
+    desc = SortedDict(ordering='DESC')
+
+    for _ in range(2000):
+        values.append(random.uniform(0.0, 100000.0))
+    values = set(values)
+
+    for v in values:
+        asc[v] = str(v)
+        desc[v] = str(v)
+
+    lst = asc.to_list(20)
+    _keys = list(list(zip(*lst))[0])
+    assert _keys == list(asc.keys())[:20]
+    assert sorted(_keys) == _keys
+    previous = None
+    for key, val in lst:
+        assert val == asc[key]
+        val = float(val)
+        if previous:
+            assert val > previous
+        previous = val
+
+    lst = desc.to_list(20)
+    _keys = list(list(zip(*lst))[0])
+    assert _keys == list(desc.keys())[:20]
+    assert list(reversed(sorted(_keys))) == _keys
+    previous = None
+    for key, val in lst:
+        assert val == desc[key]
+        val = float(val)
+        if previous:
+            assert val < previous
+        previous = val
 
 def test_init_from_dict():
     with pytest.raises(TypeError):


### PR DESCRIPTION
For Issue #13, add `to_list` method to `SortedDict` and some test cases for it. It takes one optional argument `n_levels` as an input parameter.

The method will return a list of (key, value) tuples with the length specified in the input argument. If no argument is passed or the argument is larger than the length of self->data, return items with a length of `self->data`.

**Performance Result**
I also updated `perf/performance_test.py` to benchmark read performance (get depth of 10 for different dict types). `to_list` gives about 2x~2.5x improvement over `.index` of the current implementation, and large improvement over `to_dict` (when data length is large).

Here are some benchmark log:
```
===== Read Performance =====
C lib with 10 entries (access)
- index impl Time: 0.003099 ms
- todict impl Time: 0.005007 ms
- iter impl (incorrect when called multiple times) Time: 0.001431 ms
- tolist impl Time: 0.001907 ms
Orderbook SortedDict Python lib with 10 entries (access)
Time: 0.001431 ms
Python dict (non sorted) with 10 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 100 entries (access)
- index impl Time: 0.002146 ms
- todict impl Time: 0.010729 ms
- iter impl (incorrect when called multiple times) Time: 0.001192 ms
- tolist impl Time: 0.001192 ms
Orderbook SortedDict Python lib with 100 entries (access)
Time: 0.001192 ms
Python dict (non sorted) with 100 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 200 entries (access)
- index impl Time: 0.001907 ms
- todict impl Time: 0.018835 ms
- iter impl (incorrect when called multiple times) Time: 0.001192 ms
- tolist impl Time: 0.000954 ms
Orderbook SortedDict Python lib with 200 entries (access)
Time: 0.001431 ms
Python dict (non sorted) with 200 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 400 entries (access)
- index impl Time: 0.001907 ms
- todict impl Time: 0.033617 ms
- iter impl (incorrect when called multiple times) Time: 0.001431 ms
- tolist impl Time: 0.001431 ms
Orderbook SortedDict Python lib with 400 entries (access)
Time: 0.001669 ms
Python dict (non sorted) with 400 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 500 entries (access)
- index impl Time: 0.002384 ms
- todict impl Time: 0.040770 ms
- iter impl (incorrect when called multiple times) Time: 0.001669 ms
- tolist impl Time: 0.001192 ms
Orderbook SortedDict Python lib with 500 entries (access)
Time: 0.001431 ms
Python dict (non sorted) with 500 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 1000 entries (access)
- index impl Time: 0.004053 ms
- todict impl Time: 0.085115 ms
- iter impl (incorrect when called multiple times) Time: 0.001431 ms
- tolist impl Time: 0.002146 ms
Orderbook SortedDict Python lib with 1000 entries (access)
Time: 0.001669 ms
Python dict (non sorted) with 1000 entries (access)
Time: 0.001431 ms
===== Read Performance =====
C lib with 2000 entries (access)
- index impl Time: 0.007629 ms
- todict impl Time: 0.265598 ms
- iter impl (incorrect when called multiple times) Time: 0.002146 ms
- tolist impl Time: 0.002384 ms
Orderbook SortedDict Python lib with 2000 entries (access)
Time: 0.004292 ms
Python dict (non sorted) with 2000 entries (access)
Time: 0.001192 ms
===== Read Performance =====
C lib with 10000 entries (access)
- index impl Time: 0.012159 ms
- todict impl Time: 1.729488 ms
- iter impl (incorrect when called multiple times) Time: 0.003099 ms
- tolist impl Time: 0.004530 ms
Orderbook SortedDict Python lib with 10000 entries (access)
Time: 0.008345 ms
Python dict (non sorted) with 10000 entries (access)
Time: 0.001669 ms
===== Read Performance =====
C lib with 100000 entries (access)
- index impl Time: 0.010014 ms
- todict impl Time: 27.706623 ms
- iter impl (incorrect when called multiple times) Time: 0.006676 ms
- tolist impl Time: 0.004530 ms
Orderbook SortedDict Python lib with 100000 entries (access)
Time: 0.009060 ms
Python dict (non sorted) with 100000 entries (access)
Time: 0.004053 ms
===== Read Performance =====
C lib with 200000 entries (access)
- index impl Time: 0.010967 ms
- todict impl Time: 71.116686 ms
- iter impl (incorrect when called multiple times) Time: 0.009060 ms
- tolist impl Time: 0.006437 ms
Orderbook SortedDict Python lib with 200000 entries (access)
Time: 0.010014 ms
Python dict (non sorted) with 200000 entries (access)
Time: 0.003576 ms
===== Read Performance =====
C lib with 500000 entries (access)
- index impl Time: 0.014305 ms
- todict impl Time: 220.933676 ms
- iter impl (incorrect when called multiple times) Time: 0.013828 ms
- tolist impl Time: 0.005722 ms
Orderbook SortedDict Python lib with 500000 entries (access)
Time: 0.011206 ms
Python dict (non sorted) with 500000 entries (access)
Time: 0.004530 ms

```