### PR TITLE
Resets the iterator each time iter() is called (Fixes issue #22)

### DIFF
--- a/orderbook/sorteddict.c
+++ b/orderbook/sorteddict.c
@@ -494,6 +494,13 @@ int SortedDict_contains(const SortedDict *self, PyObject *value)
 }
 
 /* iterator methods */
+PyObject *SortedDict_getiter(SortedDict *self)
+{
+    Py_INCREF(self);
+    self->iterator_index = -1;
+    return self;
+}
+
 PyObject *SortedDict_next(SortedDict *self)
 {
     if (self->iterator_index == -1) {

--- a/orderbook/sorteddict.h
+++ b/orderbook/sorteddict.h
@@ -51,6 +51,7 @@ int SortedDict_setitem(SortedDict *self, PyObject *key, PyObject *value);
 
 int SortedDict_contains(const SortedDict *self, PyObject *value);
 
+PyObject *SortedDict_getiter(SortedDict *self);
 PyObject *SortedDict_next(SortedDict *self);
 
 
@@ -101,7 +102,7 @@ static PyTypeObject SortedDictType = {
     .tp_methods = SortedDict_methods,
     .tp_as_mapping = &SortedDict_mapping,
     .tp_as_sequence = &SortedDict_seq,
-    .tp_iter  = PyObject_SelfIter,
+    .tp_iter  = (getiterfunc) SortedDict_getiter,
     .tp_iternext = (iternextfunc) SortedDict_next,
     .tp_dictoffset = 0,
 };


### PR DESCRIPTION
Resets the iterator_index back to -1 each time iter() is called, fixing the case when a for loop is exited with a break and the iterator_index does not get set back to -1.